### PR TITLE
add test for statistics endpoint

### DIFF
--- a/tests/controllers/AppController.test.js
+++ b/tests/controllers/AppController.test.js
@@ -1,0 +1,68 @@
+/* eslint-disable import/no-named-as-default */
+import dbClient from '../../utils/db';
+
+describe('+ AppController', () => {
+  before(function (done) {
+    this.timeout(10000);
+    Promise.all([dbClient.usersCollection(), dbClient.filesCollection()])
+      .then(([usersCollection, filesCollection]) => {
+        Promise.all([usersCollection.deleteMany({}), filesCollection.deleteMany({})])
+          .then(() => done())
+          .catch((deleteErr) => done(deleteErr));
+      }).catch((connectErr) => done(connectErr));
+  });
+
+  describe('+ GET: /status', () => {
+    it('+ Services are online', function (done) {
+      request.get('/status')
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res.body).to.deep.eql({ redis: true, db: true });
+          done();
+        });
+    });
+  });
+
+  describe('+ GET: /stats', () => {
+    it('+ Correct statistics about db collections', function (done) {
+      request.get('/stats')
+        .expect(200)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res.body).to.deep.eql({ users: 0, files: 0 });
+          done();
+        });
+    });
+
+    it('+ Correct statistics about db collections [alt]', function (done) {
+      this.timeout(10000);
+      Promise.all([dbClient.usersCollection(), dbClient.filesCollection()])
+        .then(([usersCollection, filesCollection]) => {
+          Promise.all([
+            usersCollection.insertMany([{ email: 'john@mail.com' }]),
+            filesCollection.insertMany([
+              { name: 'foo.txt', type: 'file'},
+              {name: 'pic.png', type: 'image' },
+            ])
+          ])
+            .then(() => {
+              request.get('/stats')
+                .expect(200)
+                .end((err, res) => {
+                  if (err) {
+                    return done(err);
+                  }
+                  expect(res.body).to.deep.eql({ users: 1, files: 2 });
+                  done();
+                });
+            })
+            .catch((deleteErr) => done(deleteErr));
+        }).catch((connectErr) => done(connectErr));
+    });
+  });
+});


### PR DESCRIPTION
Its a unit test for the `/stats` endpoint of an application. It uses Mocha and Chai for testing and Supertest for HTTP assertions.

The test does the following:

1. It sets a timeout of 10 seconds for the test to complete.
2. It connects to the users and files collections in the database.
3. It inserts a user with email 'john@mail.com' into the users collection and two files into the files collection.
4. It sends a GET request to the `/stats` endpoint.
5. It expects the HTTP response status to be 200 (OK).
6. It checks if the response body is equal to `{ users: 1, files: 2 }`, which means there is one user and two files in the database.
7. If any of the above steps fail, it calls the `done` function with the error as an argument, which will cause the test to fail. If all steps succeed, it calls `done` with no arguments, which will cause the test to pass.