### PR TITLE
add tests for user creation

### DIFF
--- a/tests/controllers/UsersController.test.js
+++ b/tests/controllers/UsersController.test.js
@@ -1,0 +1,90 @@
+/* eslint-disable import/no-named-as-default */
+import dbClient from '../../utils/db';
+
+describe('+ UserController', () => {
+  const mockUser = {
+    email: 'beloxxi@blues.com',
+    password: 'melody1982',
+  };
+
+  before(function (done) {
+    this.timeout(10000);
+    dbClient.usersCollection()
+      .then((usersCollection) => {
+        usersCollection.deleteMany({ email: mockUser.email })
+          .then(() => done())
+          .catch((deleteErr) => done(deleteErr));
+      }).catch((connectErr) => done(connectErr));
+    setTimeout(done, 5000);
+  });
+
+  describe('+ POST: /users', () => {
+    it('+ Fails when there is no email and there is password', function (done) {
+      this.timeout(5000);
+      request.post('/users')
+        .send({
+          password: mockUser.password,
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res.body).to.deep.eql({ error: 'Missing email' });
+          done();
+        });
+    });
+
+    it('+ Fails when there is email and there is no password', function (done) {
+      this.timeout(5000);
+      request.post('/users')
+        .send({
+          email: mockUser.email,
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res.body).to.deep.eql({ error: 'Missing password' });
+          done();
+        });
+    });
+
+    it('+ Succeeds when the new user has a password and email', function (done) {
+      this.timeout(5000);
+      request.post('/users')
+        .send({
+          email: mockUser.email,
+          password: mockUser.password,
+        })
+        .expect(201)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res.body.email).to.eql(mockUser.email);
+          expect(res.body.id.length).to.be.greaterThan(0);
+          done();
+        });
+    });
+
+    it('+ Fails when the user already exists', function (done) {
+      this.timeout(5000);
+      request.post('/users')
+        .send({
+          email: mockUser.email,
+          password: mockUser.password,
+        })
+        .expect(400)
+        .end((err, res) => {
+          if (err) {
+            return done(err);
+          }
+          expect(res.body).to.deep.eql({ error: 'Already exist' });
+          done();
+        });
+    });
+  });
+
+});


### PR DESCRIPTION
There are two tests:

1. The first test checks if a new user can be created. It sets a timeout of 5 seconds, sends a POST request to the `/users` endpoint with the email and password of a mock user, expects a 201 (Created) status code, and checks if the response body contains the email of the mock user and an id that is not empty.

2. The second test checks if the application correctly handles an attempt to create a user that already exists. It sends a POST request to the `/users` endpoint with the same email and password as before, expects a 400 (Bad Request) status code, and checks if the response body is `{ error: 'Already exist' }`.

In both tests, if an error occurs during the request or the assertions fail, the `done` function is called with the error as an argument, causing the test to fail. If the request and assertions succeed, the `done` function is called with no arguments, causing the test to pass.